### PR TITLE
package fix for yarn build

### DIFF
--- a/es6-three-starter-template/package.json
+++ b/es6-three-starter-template/package.json
@@ -2,7 +2,7 @@
   "name": "es6-starter-template",
   "version": "1.0.0",
   "description": "Starter template with Shader Park",
-  "main": "index.js",
+  "default": "dist/index.html",
   "repository": "https://github.com/shader-park/shader-park-examples",
   "author": "Torin Blankensmith & Peter Whidden",
   "license": "MIT",


### PR DESCRIPTION
**Problem:**
On _yarn build_ you get error:
```
🚨 Build failed.

@parcel/namer-default: Target "main" declares an output file path of "index.js"
which does not match the compiled bundle type "html".

/package.json:5:11
    4 |   "description": "Starter template with Shader Park",
  > 5 |   "main": "index.js",
  >   |           ^^^^^^^^^^ Did you mean "index.html"?
    6 |   "repository": "https://github.com/shader-park/shader-park-examples",
    7 |   "author": "Torin Blankensmith & Peter Whidden",

  💡 Try changing the file extension of "main" in package.json.
```

**Solution:**
Changing the main property to default and linking it to dist / main.html